### PR TITLE
don't split scene performer names in the middle

### DIFF
--- a/frontend/src/pages/scenes/styles.scss
+++ b/frontend/src/pages/scenes/styles.scss
@@ -26,6 +26,7 @@
 }
 
 .scene-performer {
+  display: inline-block;
   margin-right: 0.5rem;
 }
 


### PR DESCRIPTION
See `Monica Sweetheart` in the example below:

![before](https://user-images.githubusercontent.com/66393006/121772741-11cf9000-cb80-11eb-9900-20568c8c6838.png)
![after](https://user-images.githubusercontent.com/66393006/121772742-1300bd00-cb80-11eb-93bb-5e091d4fc772.png)